### PR TITLE
Place cursor at the end of inserted text

### DIFF
--- a/lua/copilot-client/ui/init.lua
+++ b/lua/copilot-client/ui/init.lua
@@ -78,14 +78,7 @@ M.insert_completion = function(completion)
 		lines[1] = lines[1]:sub(2)
 	end
 
-	vim.api.nvim_buf_set_text(
-		0,
-		completion.position.line,
-		completion.position.character,
-		completion.position.line,
-		completion.position.character,
-		lines
-	)
+	vim.api.nvim_put(lines, "c", true, true)
 end
 
 return M


### PR DESCRIPTION
Places the cursor at the end of inserted text.
I find this to be much more intuitive considering this should work just like regular completions.
Also useful when copilot generates line by line instead of a single chunk of multiple lines.